### PR TITLE
udpated "shadow" field for Gigalityh family

### DIFF
--- a/pogo_pkm.json
+++ b/pogo_pkm.json
@@ -26914,7 +26914,7 @@
             "Rock Blast",
             "Stone Edge"
         ],
-        "shadow": false,
+        "shadow": true,
         "shadow_released": true,
         "released": true
     },
@@ -26939,7 +26939,7 @@
             "Bulldoze",
             "Stone Edge"
         ],
-        "shadow": false,
+        "shadow": true,
         "shadow_released": true,
         "released": true
     },
@@ -26968,7 +26968,7 @@
         "elite_cm": [
             "Meteor Beam"
         ],
-        "shadow": false,
+        "shadow": true,
         "shadow_released": true,
         "released": true
     },

--- a/pogo_pkm_manual.json
+++ b/pogo_pkm_manual.json
@@ -103,18 +103,21 @@
         "id": 524,
         "name": "Roggenrola",
         "form": "Normal",
+        "shadow": true,
         "shadow_released": true
     },
     {
         "id": 525,
         "name": "Boldore",
         "form": "Normal",
+        "shadow": true,
         "shadow_released": true
     },
     {
         "id": 526,
         "name": "Gigalith",
         "form": "Normal",
+        "shadow": true,
         "shadow_released": true
     },
     {


### PR DESCRIPTION
Both "shadow" and "shadow_released" need to be true in this case.

If "shadow" is true, a pokemon's shadow ratings are shown in its page.

If "shadow" and "shadow_released" are true, the pokemon's shadow forms appear on the strongest lists.